### PR TITLE
add outputs for state backend module

### DIFF
--- a/modules/opentofu_state_backend/main.tf
+++ b/modules/opentofu_state_backend/main.tf
@@ -24,6 +24,16 @@ resource "aws_dynamodb_table" "main" {
   }
 }
 
+output "bucket_name" {
+  description = "Name of the s3 bucket"
+  value       = aws_s3_bucket.main.bucket
+}
+
+output "dynamodb_table_name" {
+  description = "Name of the dynamodb table used for locking"
+  value       = aws_dynamodb_table.main.name
+}
+
 output "usage" {
   description = "Example state backend configuration"
   value       = <<EOF


### PR DESCRIPTION
This allows referencing the created bucket name for e.g. setting up bucket versioning as done in week 8.